### PR TITLE
Turned the LiDAR on during startup to connect it to the SDK

### DIFF
--- a/MicrocontrollerCode/src/main.cpp
+++ b/MicrocontrollerCode/src/main.cpp
@@ -26,6 +26,10 @@ Adafruit_ICM20948 icm;
 
 
 void setup() {
+
+    setupLidar();
+    lidarState(true); // Enabling the LiDAR at start so it can grab the SDK correctly
+
     Serial.begin(115200);
 
     while(!Serial){
@@ -65,7 +69,7 @@ void setup() {
     setAllFans(startDutyCycles);
     setupRPMCounter();
     setupLight();
-    setupLidar();
+
 
 }
 


### PR DESCRIPTION
This turns the LiDAR on even before the MicroROS agent connects. This is done because the LiDAR SDK needs the LiDAR to be on when it runs, or it will fail and won't connect. This way, when the wheelchair boots up, the LiDAR is running, so it will grab the SDK, and then it can be turned on and off.